### PR TITLE
Trigger deployments and fix frontend Nginx backend URL

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:1.27-alpine
 
-COPY docker/frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker/frontend/nginx.conf /etc/nginx/templates/default.conf.template
+
 COPY index.html styles.css books.json /usr/share/nginx/html/
 COPY js /usr/share/nginx/html/js
 COPY images /usr/share/nginx/html/images

--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -5,7 +5,7 @@ server {
     index index.html;
 
     location /resources/ {
-        proxy_pass http://backend:3000;
+        proxy_pass ${BACKEND_URL};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -13,7 +13,7 @@ server {
     }
 
     location /health {
-        proxy_pass http://backend:3000/health;
+        proxy_pass ${BACKEND_URL}/health;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This pull request updates the frontend Docker configuration to support dynamic backend URLs via environment variables, making the deployment more flexible and configurable. The main changes are related to how the frontend Nginx server proxies requests to the backend service.

Configuration and deployment improvements:

* Updated `nginx.conf` to use the `${BACKEND_URL}` environment variable instead of a hardcoded backend address for proxying `/resources/` and `/health` routes, allowing dynamic backend configuration at runtime.
* Changed the Dockerfile to copy the Nginx configuration as a template (`default.conf.template`) to the `/etc/nginx/templates/` directory, enabling Nginx to substitute environment variables when starting the container.