### PR TITLE
fix: enable proxy_ssl_server_name and correct Host header for nginx HTTPS upstream

### DIFF
--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -6,7 +6,8 @@ server {
 
     location /resources/ {
         proxy_pass ${BACKEND_URL};
-        proxy_set_header Host $host;
+        proxy_ssl_server_name on;
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -14,7 +15,8 @@ server {
 
     location /health {
         proxy_pass ${BACKEND_URL}/health;
-        proxy_set_header Host $host;
+        proxy_ssl_server_name on;
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Problem

PR #35 set `BACKEND_URL` but the staging frontend still returns `502 Bad Gateway` for all proxied requests (`/health`, `/resources/api_user.php`).

Root cause: nginx sends the frontend's own hostname as the `Host` header (`$host`) and does not enable TLS SNI for the HTTPS upstream. Azure Container Apps ingress validates both the `Host` header and SNI against the backend FQDN, which causes the upstream connection to fail with 502.

## Changes

- **`docker/frontend/nginx.conf`** — both `/resources/` and `/health` proxy blocks:

  1. `proxy_ssl_server_name on;` — enables TLS Server Name Indication so ACA accepts the SSL handshake
  2. `proxy_set_header Host $proxy_host;` — sends the backend FQDN (from `BACKEND_URL`) as the Host header instead of the frontend's hostname

## Verification after deployment

```bash
curl -i https://bookrunner-frontend-staging.blacksky-1181b208.eastasia.azurecontainerapps.io/health
```

Expected: `200 {"status":"ok"}` (was `502 Bad Gateway`)

Then test login via the frontend proxy.
