### PR TITLE
fix: force HTTP/1.1 upstream for Azure Container Apps proxy

### DIFF
--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -7,19 +7,23 @@ server {
     location /resources/ {
         proxy_pass ${BACKEND_URL};
         proxy_ssl_server_name on;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
     }
 
     location /health {
         proxy_pass ${BACKEND_URL}/health;
         proxy_ssl_server_name on;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
     }
 
     location / {


### PR DESCRIPTION
## Problem

nginx uses **HTTP/1.0** by default for proxy upstream connections. Azure Container Apps ingress (Envoy) requires **HTTP/1.1** and returns:

```
HTTP/1.1 426 Upgrade Required
Upgrade Required
```

The frontend was reaching the backend but the protocol mismatch blocked every proxied request.

## Changes

**`docker/frontend/nginx.conf`** — both proxy blocks (`/resources/` and `/health`):

- `proxy_http_version 1.1` — tells nginx to speak HTTP/1.1 upstream (required by ACA)
- `proxy_set_header Connection ""` — clears the default Connection header so HTTP/1.1 keep-alive works
- `X-Forwarded-Proto https` — hardcoded instead of `$scheme` because the frontend container receives requests as HTTP internally, but the upstream to the backend is HTTPS

## Verification after merge

```bash
curl -i https://bookrunner-frontend-staging.blacksky-1181b208.eastasia.azurecontainerapps.io/health
```

Expected: `200 {"status":"ok"}` (was `426 Upgrade Required`)
