### PR TITLE
fix: migrate cart_items and order_items book_id from UUID to VARCHAR(120)

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -35,6 +35,12 @@ WHERE volume IS NULL OR BTRIM(volume) = '';
 UPDATE books
 SET book_id = gen_random_uuid()::text
 WHERE book_id IS NULL OR BTRIM(book_id) = '';
+
+ALTER TABLE cart_items
+  ALTER COLUMN book_id TYPE VARCHAR(120) USING book_id::text;
+
+ALTER TABLE order_items
+  ALTER COLUMN book_id TYPE VARCHAR(120) USING book_id::text;
 `;
 
 const resolvePort = (rawPort) => {

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -127,6 +127,14 @@ test('startup migration adds missing books columns with IF NOT EXISTS', async (t
   assert.match(calls[1], /WHERE volume IS NULL OR BTRIM\(volume\) = ''/i);
   assert.match(calls[1], /UPDATE books[\s\S]*SET book_id = gen_random_uuid\(\)/i);
   assert.match(calls[1], /WHERE book_id IS NULL OR BTRIM\(book_id\) = ''/i);
+  assert.match(
+    calls[1],
+    /ALTER TABLE cart_items[\s\S]*ALTER COLUMN book_id TYPE VARCHAR\(120\) USING book_id::text/i,
+  );
+  assert.match(
+    calls[1],
+    /ALTER TABLE order_items[\s\S]*ALTER COLUMN book_id TYPE VARCHAR\(120\) USING book_id::text/i,
+  );
   assert.equal(calls[2], 'COMMIT');
 });
 


### PR DESCRIPTION
## Description
Fixes the staging 500 error on `POST /api/cart`.

## Root Cause
The staging database still has `cart_items.book_id` and `order_items.book_id` as type `UUID`, but the app now treats book IDs as text (e.g. `OP001`, `classroom-of-the-elite::1`). PostgreSQL rejects the text values with:
```
invalid input syntax for type uuid: "classroom-of-the-elite::1"
```

## Changes
- **`backend/src/index.js`** — Added `ALTER TABLE cart_items ... ALTER COLUMN book_id TYPE VARCHAR(120)` and the same for `order_items` to the startup schema migration.
- **`backend/src/index.test.js`** — Added assertions verifying the two new `ALTER TABLE` statements are emitted.

All 65 tests pass.

## Closes
https://github.com/Josan88/BookRunner/issues/55