### PR TITLE
feat: Add k6 performance testing and deploy timing evidence (#15)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,6 +135,10 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Record deploy start time
+        id: deploy_start
+        run: echo "timestamp=$(date +%s)" >> "$GITHUB_OUTPUT"
+
       - name: Verify staging backend Container App exists
         env:
           ACA_APP: ${{ secrets.ACA_STAGING_BACKEND_APP }}
@@ -159,6 +163,29 @@ jobs:
             --image "$BACKEND_IMAGE:${{ needs.build-and-push.outputs.image-tag }}" \
             --set-env-vars DATABASE_URL="$DATABASE_URL" JWT_SECRET="$JWT_SECRET" FRONTEND_ORIGIN="$FRONTEND_ORIGIN"
 
+      - name: Wait for staging backend to be running
+        env:
+          ACA_APP: ${{ secrets.ACA_STAGING_BACKEND_APP }}
+          ACA_RG: ${{ secrets.ACA_RESOURCE_GROUP }}
+        run: |
+          echo "Waiting for Container App to reach Running state..."
+          for i in $(seq 1 30); do
+            STATE=$(az containerapp show \
+              --name "$ACA_APP" \
+              --resource-group "$ACA_RG" \
+              --query "properties.runningStatus" \
+              --output tsv 2>/dev/null || echo "unknown")
+            echo "  Attempt $i: runningStatus=$STATE"
+            if [[ "$STATE" == "Running" ]]; then
+              echo "Container App is Running."
+              break
+            fi
+            sleep 10
+          done
+          if [[ "$STATE" != "Running" ]]; then
+            echo "::warning::Container App did not reach Running state within 5 minutes."
+          fi
+
       - name: Get staging backend URL
         env:
           ACA_APP: ${{ secrets.ACA_STAGING_BACKEND_APP }}
@@ -174,6 +201,37 @@ jobs:
             exit 1
           fi
           echo "STAGING_BACKEND_URL=https://${FQDN}" >> "$GITHUB_ENV"
+
+      - name: Record deploy duration
+        id: deploy_end
+        env:
+          ACA_APP: ${{ secrets.ACA_STAGING_BACKEND_APP }}
+          ACA_RG: ${{ secrets.ACA_RESOURCE_GROUP }}
+        run: |
+          END=$(date +%s)
+          START=${{ steps.deploy_start.outputs.timestamp }}
+          DURATION=$((END - START))
+          echo "deploy_duration=${DURATION}" >> "$GITHUB_OUTPUT"
+          echo "Deploy duration: ${DURATION}s (target: ≤300s)"
+          if [[ $DURATION -le 300 ]]; then
+            echo "Result: PASS"
+          else
+            echo "Result: FAIL (exceeded 5-minute target)"
+          fi
+
+      - name: Write deploy metrics
+        env:
+          ACA_APP: ${{ secrets.ACA_STAGING_BACKEND_APP }}
+        run: |
+          PASSED=$( [[ ${{ steps.deploy_end.outputs.deploy_duration }} -le 300 ]] && echo "true" || echo "false" )
+          echo "{\"deploy_duration_seconds\":${{ steps.deploy_end.outputs.deploy_duration }},\"target_seconds\":300,\"passed\":${PASSED},\"commit\":\"${{ github.sha }}\",\"image_tag\":\"${{ needs.build-and-push.outputs.image-tag }}\",\"app_name\":\"${{ env.ACA_APP }}\",\"environment\":\"staging\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > deploy-metrics.json
+
+      - name: Upload deploy metrics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-metrics-staging
+          path: deploy-metrics.json
+          retention-days: 30
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -220,6 +278,10 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Record deploy start time
+        id: deploy_start
+        run: echo "timestamp=$(date +%s)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy backend to production Container App
         uses: azure/container-apps-deploy-action@v2
         with:
@@ -227,6 +289,59 @@ jobs:
           containerAppName: ${{ secrets.ACA_PRODUCTION_BACKEND_APP }}
           imageToDeploy: ${{ env.BACKEND_IMAGE }}:${{ needs.build-and-push.outputs.image-tag }}
           environmentVariables: DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }} JWT_SECRET=${{ secrets.PRODUCTION_JWT_SECRET }} FRONTEND_ORIGIN=${{ secrets.PRODUCTION_FRONTEND_ORIGIN }}
+
+      - name: Wait for production backend to be running
+        env:
+          ACA_APP: ${{ secrets.ACA_PRODUCTION_BACKEND_APP }}
+          ACA_RG: ${{ secrets.ACA_RESOURCE_GROUP }}
+        run: |
+          echo "Waiting for Container App to reach Running state..."
+          for i in $(seq 1 30); do
+            STATE=$(az containerapp show \
+              --name "$ACA_APP" \
+              --resource-group "$ACA_RG" \
+              --query "properties.runningStatus" \
+              --output tsv 2>/dev/null || echo "unknown")
+            echo "  Attempt $i: runningStatus=$STATE"
+            if [[ "$STATE" == "Running" ]]; then
+              echo "Container App is Running."
+              break
+            fi
+            sleep 10
+          done
+          if [[ "$STATE" != "Running" ]]; then
+            echo "::warning::Container App did not reach Running state within 5 minutes."
+          fi
+
+      - name: Record deploy duration
+        id: deploy_end
+        env:
+          ACA_APP: ${{ secrets.ACA_PRODUCTION_BACKEND_APP }}
+        run: |
+          END=$(date +%s)
+          START=${{ steps.deploy_start.outputs.timestamp }}
+          DURATION=$((END - START))
+          echo "deploy_duration=${DURATION}" >> "$GITHUB_OUTPUT"
+          echo "Deploy duration: ${DURATION}s (target: ≤300s)"
+          if [[ $DURATION -le 300 ]]; then
+            echo "Result: PASS"
+          else
+            echo "Result: FAIL (exceeded 5-minute target)"
+          fi
+
+      - name: Write deploy metrics
+        env:
+          ACA_APP: ${{ secrets.ACA_PRODUCTION_BACKEND_APP }}
+        run: |
+          PASSED=$( [[ ${{ steps.deploy_end.outputs.deploy_duration }} -le 300 ]] && echo "true" || echo "false" )
+          echo "{\"deploy_duration_seconds\":${{ steps.deploy_end.outputs.deploy_duration }},\"target_seconds\":300,\"passed\":${PASSED},\"commit\":\"${{ github.sha }}\",\"image_tag\":\"${{ needs.build-and-push.outputs.image-tag }}\",\"app_name\":\"${{ env.ACA_APP }}\",\"environment\":\"production\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > deploy-metrics.json
+
+      - name: Upload deploy metrics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-metrics-production
+          path: deploy-metrics.json
+          retention-days: 30
 
       - name: Get production backend URL
         run: |

--- a/backend/src/routes/books.js
+++ b/backend/src/routes/books.js
@@ -7,7 +7,7 @@ const db = require('../db');
 const router = express.Router();
 const booksLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 200,
+  max: Number(process.env.RATE_LIMIT_BOOKS_MAX) || 200,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later' },

--- a/backend/src/routes/cart.js
+++ b/backend/src/routes/cart.js
@@ -9,7 +9,7 @@ const { asyncHandler, requireAuth } = require('../middleware/auth');
 const router = express.Router();
 const cartLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
+  max: Number(process.env.RATE_LIMIT_CART_MAX) || 100,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later' },

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -16,7 +16,7 @@ const BCRYPT_ROUNDS = 12;
 
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 20,
+  max: Number(process.env.RATE_LIMIT_AUTH_MAX) || 20,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later' },
@@ -24,7 +24,7 @@ const authLimiter = rateLimit({
 
 const profileLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
+  max: Number(process.env.RATE_LIMIT_PROFILE_MAX) || 100,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later' },

--- a/docs/evidence/performance/README.md
+++ b/docs/evidence/performance/README.md
@@ -1,0 +1,78 @@
+# Performance Evidence
+
+This directory contains captured performance and scalability evidence for the BookRunner application, mapped to the success metrics defined in the project brief.
+
+## Metrics Summary
+
+| Metric | Target | Evidence File(s) | Actual | Status |
+|--------|--------|-------------------|--------|--------|
+| Avg response time | ≤ 2 seconds | `ramping-summary.json`, `ramping-report.html` | _(run tests to populate)_ | |
+| Concurrent users | ≥ 50 | `ramping-summary.json` (ramping-vus scenario) | _(run tests to populate)_ | |
+| Throughput | ≥ 20 req/s | `throughput-summary.json` (constant-arrival-rate scenario) | _(run tests to populate)_ | |
+| Deployment time | ≤ 5 minutes | `deploy-metrics.json`, CD workflow logs | _(run deploy to populate)_ | |
+
+## How to Capture Evidence
+
+### Prerequisites
+
+- [k6](https://grafana.com/docs/k6/latest/set-up/install-k6/) installed
+- Azure CLI authenticated (`az login`) for deploy timing
+- Staging environment deployed and accessible
+
+### Step 1: Run k6 load tests
+
+```bash
+cd performance-test
+chmod +x run-tests.sh
+./run-tests.sh --base-url https://<staging-backend-url>
+```
+
+This runs two tests:
+
+1. **Ramping VUs** (default) — ramps 0→20→50→100 VUs to prove concurrency and response time
+2. **Constant throughput** — maintains 20 req/s arrival rate to prove throughput
+
+Results are saved to `performance-test/results/` and copied here.
+
+### Step 2: Capture deploy timing
+
+After a deployment, run:
+
+```bash
+./run-tests.sh \
+  --base-url https://<staging-backend-url> \
+  --deploy-timing \
+  --deploy-app <aca-app-name> \
+  --deploy-rg <resource-group>
+```
+
+Or check the GitHub Actions CD workflow output for `deploy-metrics.json` as a build artifact.
+
+### Step 3: Screenshot reports
+
+Open `ramping-report.html` or `throughput-report.html` in a browser and take screenshots for the final report/presentation.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `ramping-summary.json` | k6 summary for ramping VUs scenario (response time, concurrency) |
+| `throughput-summary.json` | k6 summary for constant throughput scenario |
+| `ramping-report.html` | Visual HTML report for ramping VUs test |
+| `throughput-report.html` | Visual HTML report for throughput test |
+| `deploy-metrics.json` | Deployment duration measurement |
+| `ramping-results.json` | Raw per-request data from ramping VUs test |
+| `throughput-results.json` | Raw per-request data from throughput test |
+
+## Mapping to Project Brief
+
+- **Response time ≤ 2s**: Measured by `http_req_duration` avg in ramping VUs scenario
+- **Concurrent users ≥ 50**: Demonstrated by sustaining 50 VUs in ramping scenario
+- **Throughput ≥ 20 req/s**: Measured by `http_reqs.rate` in constant throughput scenario
+- **Deploy time ≤ 5 min**: Measured by `deploy_duration_seconds` from CD workflow
+
+## Related Issues
+
+- Parent tracker: [#1 — Implementation Tracker](https://github.com/Josan88/BookRunner/issues/1)
+- Monitoring: [#8 — Azure Monitor & Evidence](https://github.com/Josan88/BookRunner/issues/8)
+- This issue: [#15 — Performance Evidence](https://github.com/Josan88/BookRunner/issues/15)

--- a/performance-test/deploy-timing.sh
+++ b/performance-test/deploy-timing.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# deploy-timing.sh — Measure deployment duration from image update to running state
+#
+# Usage:
+#   ./deploy-timing.sh --app-name <aca-app> --resource-group <rg> [--timeout 300]
+#
+# Outputs:
+#   deploy-metrics.json  — JSON with deploy_duration_seconds, commit, timestamp
+#
+# Exit code:
+#   0 — deploy succeeded within timeout
+#   1 — deploy failed or timed out
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+APP_NAME=""
+RESOURCE_GROUP=""
+TIMEOUT_SECONDS=300
+POLL_INTERVAL=10
+COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')}"
+OUTPUT_FILE="${OUTPUT_FILE:-deploy-metrics.json}"
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app-name) APP_NAME="$2"; shift 2 ;;
+    --resource-group) RESOURCE_GROUP="$2"; shift 2 ;;
+    --timeout) TIMEOUT_SECONDS="$2"; shift 2 ;;
+    --commit) COMMIT_SHA="$2"; shift 2 ;;
+    --output) OUTPUT_FILE="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$APP_NAME" || -z "$RESOURCE_GROUP" ]]; then
+  echo "Usage: $0 --app-name <aca-app> --resource-group <rg> [--timeout 300]"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Record start time
+# ---------------------------------------------------------------------------
+START_EPOCH=$(date +%s)
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Deploy timing started"
+echo "  App:           $APP_NAME"
+echo "  Resource Group: $RESOURCE_GROUP"
+echo "  Timeout:       ${TIMEOUT_SECONDS}s"
+echo "  Commit:        $COMMIT_SHA"
+
+# ---------------------------------------------------------------------------
+# Poll until Container App is running or timeout
+# ---------------------------------------------------------------------------
+ELAPSED=0
+FINAL_STATE="unknown"
+
+while [[ $ELAPSED -lt $TIMEOUT_SECONDS ]]; do
+  # Query the running status (ACA exposes properties.runningStatus)
+  RUNNING_STATUS=$(az containerapp show \
+    --name "$APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query "properties.runningStatus" \
+    --output tsv 2>/dev/null || echo "unknown")
+
+  PROVISIONING_STATE=$(az containerapp show \
+    --name "$APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query "properties.provisioningState" \
+    --output tsv 2>/dev/null || echo "unknown")
+
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] runningStatus=$RUNNING_STATUS  provisioningState=$PROVISIONING_STATE  (${ELAPSED}s elapsed)"
+
+  if [[ "$RUNNING_STATUS" == "Running" ]]; then
+    FINAL_STATE="Running"
+    break
+  fi
+
+  if [[ "$PROVISIONING_STATE" == "Failed" ]]; then
+    FINAL_STATE="Failed"
+    echo "::error::Container App provisioning failed."
+    break
+  fi
+
+  sleep "$POLL_INTERVAL"
+  ELAPSED=$((ELAPSED + POLL_INTERVAL))
+done
+
+# ---------------------------------------------------------------------------
+# Calculate duration
+# ---------------------------------------------------------------------------
+END_EPOCH=$(date +%s)
+DURATION=$((END_EPOCH - START_EPOCH))
+
+if [[ "$FINAL_STATE" != "Running" ]]; then
+  echo "::error::Deploy did not reach Running state within ${TIMEOUT_SECONDS}s (final state: $FINAL_STATE)"
+fi
+
+echo ""
+echo "============================================"
+echo " Deploy Duration: ${DURATION}s"
+echo " Final State:     $FINAL_STATE"
+echo " Target:          ≤ ${TIMEOUT_SECONDS}s"
+if [[ $DURATION -le $TIMEOUT_SECONDS ]]; then
+  echo " Result:          PASS"
+else
+  echo " Result:          FAIL"
+fi
+echo "============================================"
+
+# ---------------------------------------------------------------------------
+# Write JSON output
+# ---------------------------------------------------------------------------
+cat > "$OUTPUT_FILE" <<EOF
+{
+  "deploy_duration_seconds": $DURATION,
+  "timeout_seconds": $TIMEOUT_SECONDS,
+  "target_seconds": 300,
+  "passed": $( [[ $DURATION -le $TIMEOUT_SECONDS ]] && echo "true" || echo "false" ),
+  "final_state": "$FINAL_STATE",
+  "commit": "$COMMIT_SHA",
+  "app_name": "$APP_NAME",
+  "resource_group": "$RESOURCE_GROUP",
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+echo ""
+echo "Metrics written to $OUTPUT_FILE"
+
+# Exit with error if deploy didn't succeed
+if [[ "$FINAL_STATE" != "Running" ]]; then
+  exit 1
+fi

--- a/performance-test/load-test.js
+++ b/performance-test/load-test.js
@@ -1,0 +1,222 @@
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Counter, Rate } from 'k6/metrics';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.1.0/index.js';
+import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/latest/dist/bundle.js';
+
+// ---------------------------------------------------------------------------
+// Custom metrics
+// ---------------------------------------------------------------------------
+const successfulLogins = new Counter('successful_logins');
+const failedRequests = new Counter('failed_requests');
+const errorRate = new Rate('error_rate');
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+const TEST_USER_COUNT = 60;
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+const rampingVUsOptions = {
+  scenarios: {
+    ramping_vus: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 20 },
+        { duration: '1m', target: 50 },
+        { duration: '2m', target: 50 },
+        { duration: '30s', target: 100 },
+        { duration: '1m', target: 100 },
+        { duration: '30s', target: 0 },
+      ],
+      gracefulRampDown: '10s',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['avg<2000', 'p(95)<3000'],
+    http_req_failed: ['rate<0.01'],
+    checks: ['rate>0.95'],
+  },
+};
+
+const constantThroughputOptions = {
+  scenarios: {
+    constant_rps: {
+      executor: 'constant-arrival-rate',
+      rate: 20,
+      timeUnit: '1s',
+      duration: '2m',
+      preAllocatedVUs: 50,
+      maxVUs: 100,
+    },
+  },
+  thresholds: {
+    http_req_duration: ['avg<2000', 'p(95)<3000'],
+    http_req_failed: ['rate<0.01'],
+    http_reqs: ['rate>=20'],
+    checks: ['rate>0.95'],
+  },
+};
+
+const SCENARIO = __ENV.SCENARIO || 'ramping';
+export const options =
+  SCENARIO === 'throughput' ? constantThroughputOptions : rampingVUsOptions;
+
+// ---------------------------------------------------------------------------
+// Setup — pre-register test users before the load test begins
+//   This avoids hitting the auth rate limiter (20 req / 15 min) during the test.
+//   Each user gets a unique email and a known password.
+// ---------------------------------------------------------------------------
+export function setup() {
+  const users = [];
+
+  for (let i = 0; i < TEST_USER_COUNT; i++) {
+    const email = `loadtest_user${i}_${Date.now()}@bookrunner.test`;
+    const password = `TestPass${i}!`;
+    const name = `LoadTest User ${i}`;
+
+    const res = http.post(
+      `${BASE_URL}/api/users`,
+      JSON.stringify({ name, email, password }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+
+    if (res.status === 201) {
+      users.push({ email, password });
+    } else if (res.status === 409) {
+      users.push({ email, password });
+    }
+  }
+
+  return { users };
+}
+
+// ---------------------------------------------------------------------------
+// Main function — runs per VU iteration
+//   Uses pre-registered users from setup. No registration during test.
+// ---------------------------------------------------------------------------
+export default function (data) {
+  if (!data.users || data.users.length === 0) {
+    errorRate.add(1);
+    failedRequests.add(1);
+    return;
+  }
+
+  // Pick a credential using VU ID (deterministic spread across users)
+  const vuIndex = __VU % data.users.length;
+  const cred = data.users[vuIndex];
+
+  let token = null;
+
+  // --- Login ---
+  group('Login user', () => {
+    const res = http.post(
+      `${BASE_URL}/api/users`,
+      JSON.stringify({ email: cred.email, password: cred.password }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        tags: { name: 'POST /api/users (login)' },
+      },
+    );
+    check(res, {
+      'login status 200': (r) => r.status === 200,
+      'login has token': (r) => {
+        try {
+          return !!JSON.parse(r.body).token;
+        } catch {
+          return false;
+        }
+      },
+    });
+    errorRate.add(res.status !== 200);
+    if (res.status !== 200) {
+      failedRequests.add(1);
+    } else {
+      successfulLogins.add(1);
+      try {
+        token = JSON.parse(res.body).token;
+      } catch {}
+    }
+  });
+
+  sleep(0.3);
+
+  // --- Browse catalog (read-heavy, no auth) ---
+  group('Browse catalog', () => {
+    const res = http.get(`${BASE_URL}/api/books`, {
+      tags: { name: 'GET /api/books' },
+    });
+    check(res, {
+      'catalog status 200': (r) => r.status === 200,
+      'catalog has books': (r) => {
+        try {
+          const body = JSON.parse(r.body);
+          return Array.isArray(body) && body.length > 0;
+        } catch {
+          return false;
+        }
+      },
+    });
+    errorRate.add(res.status !== 200);
+    if (res.status !== 200) failedRequests.add(1);
+  });
+
+  sleep(0.5);
+
+  // --- Authenticated cart operations ---
+  if (token) {
+    const authHeaders = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    };
+
+    group('Add to cart', () => {
+      const res = http.post(
+        `${BASE_URL}/api/cart`,
+        JSON.stringify({ book_title: 'One Piece', volume: 'Vol 1', quantity: 1 }),
+        {
+          headers: authHeaders,
+          tags: { name: 'POST /api/cart' },
+        },
+      );
+      check(res, {
+        'add-to-cart status 201 or 200': (r) =>
+          r.status === 201 || r.status === 200,
+      });
+      errorRate.add(res.status !== 201 && res.status !== 200);
+    });
+
+    sleep(0.3);
+
+    group('View cart', () => {
+      const res = http.get(`${BASE_URL}/api/cart`, {
+        headers: authHeaders,
+        tags: { name: 'GET /api/cart' },
+      });
+      check(res, {
+        'view-cart status 200': (r) => r.status === 200,
+      });
+      errorRate.add(res.status !== 200);
+      if (res.status !== 200) failedRequests.add(1);
+    });
+  }
+
+  sleep(1);
+}
+
+// ---------------------------------------------------------------------------
+// Summary — writes HTML + JSON reports
+// ---------------------------------------------------------------------------
+export function handleSummary(data) {
+  return {
+    'results/summary.html': htmlReport(data, {
+      title: `BookRunner Load Test — ${SCENARIO}`,
+    }),
+    'results/summary.json': JSON.stringify(data, null, 2),
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+  };
+}

--- a/performance-test/results/.gitignore
+++ b/performance-test/results/.gitignore
@@ -1,0 +1,7 @@
+# Raw k6 results (large files, not needed in repo)
+*.json
+*.csv
+*.html
+
+# Keep the directory structure
+!.gitkeep

--- a/performance-test/run-tests.sh
+++ b/performance-test/run-tests.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# run-tests.sh — Orchestrator for BookRunner performance evidence collection
+#
+# Usage:
+#   ./run-tests.sh --base-url https://your-staging.azurecontainerapps.io
+#
+# Prerequisites:
+#   - k6 installed (https://grafana.com/docs/k6/latest/set-up/install-k6/)
+#   - Azure CLI authenticated (for deploy-timing.sh)
+#
+# Outputs:
+#   performance-test/results/         — raw k6 results (JSON, CSV, HTML)
+#   docs/evidence/performance/        — copied evidence files
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+EVIDENCE_DIR="$REPO_ROOT/docs/evidence/performance"
+RESULTS_DIR="$SCRIPT_DIR/results"
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+BASE_URL=""
+SKIP_K6=false
+SKIP_DEPLOY=true
+DEPLOY_APP=""
+DEPLOY_RG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --skip-k6) SKIP_K6=true; shift ;;
+    --deploy-timing) SKIP_DEPLOY=false; shift ;;
+    --deploy-app) DEPLOY_APP="$2"; shift 2 ;;
+    --deploy-rg) DEPLOY_RG="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 --base-url <url> [--skip-k6] [--deploy-timing --deploy-app <app> --deploy-rg <rg>]"
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$BASE_URL" ]]; then
+  echo "Error: --base-url is required"
+  echo "Usage: $0 --base-url https://your-staging.azurecontainerapps.io"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+mkdir -p "$RESULTS_DIR" "$EVIDENCE_DIR"
+
+echo "============================================"
+echo " BookRunner Performance Evidence Collection"
+echo "============================================"
+echo " Base URL:  $BASE_URL"
+echo " Results:   $RESULTS_DIR"
+echo " Evidence:  $EVIDENCE_DIR"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. k6 Load Test — Ramping VUs (concurrency + response time)
+# ---------------------------------------------------------------------------
+if [[ "$SKIP_K6" == false ]]; then
+  echo "--------------------------------------------"
+  echo " [1/3] Ramping VUs test (concurrency + response time)"
+  echo "--------------------------------------------"
+  if ! command -v k6 &> /dev/null; then
+    echo "Error: k6 is not installed."
+    echo "Install: https://grafana.com/docs/k6/latest/set-up/install-k6/"
+    exit 1
+  fi
+
+  BASE_URL="$BASE_URL" SCENARIO=ramping \
+    k6 run \
+      --out json="$RESULTS_DIR/ramping-results.json" \
+      --out csv="$RESULTS_DIR/ramping-results.csv" \
+      --summary-export="$RESULTS_DIR/ramping-summary.json" \
+      "$SCRIPT_DIR/load-test.js" || true
+
+  # Copy summary to evidence dir
+  if [[ -f "$RESULTS_DIR/ramping-summary.json" ]]; then
+    cp "$RESULTS_DIR/ramping-summary.json" "$EVIDENCE_DIR/"
+  fi
+  if [[ -f "$RESULTS_DIR/summary.html" ]]; then
+    cp "$RESULTS_DIR/summary.html" "$EVIDENCE_DIR/ramping-report.html"
+  fi
+
+  echo ""
+  echo " [1/3] Ramping VUs test complete"
+  echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# 2. k6 Throughput Test — Constant arrival rate
+# ---------------------------------------------------------------------------
+if [[ "$SKIP_K6" == false ]]; then
+  echo "--------------------------------------------"
+  echo " [2/3] Constant throughput test (20 RPS)"
+  echo "--------------------------------------------"
+
+  BASE_URL="$BASE_URL" SCENARIO=throughput \
+    k6 run \
+      --out json="$RESULTS_DIR/throughput-results.json" \
+      --out csv="$RESULTS_DIR/throughput-results.csv" \
+      --summary-export="$RESULTS_DIR/throughput-summary.json" \
+      "$SCRIPT_DIR/load-test.js" || true
+
+  # Copy summary to evidence dir
+  if [[ -f "$RESULTS_DIR/throughput-summary.json" ]]; then
+    cp "$RESULTS_DIR/throughput-summary.json" "$EVIDENCE_DIR/"
+  fi
+  if [[ -f "$RESULTS_DIR/summary.html" ]]; then
+    cp "$RESULTS_DIR/summary.html" "$EVIDENCE_DIR/throughput-report.html"
+  fi
+
+  echo ""
+  echo " [2/3] Throughput test complete"
+  echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Deploy timing (optional)
+# ---------------------------------------------------------------------------
+if [[ "$SKIP_DEPLOY" == false ]]; then
+  echo "--------------------------------------------"
+  echo " [3/3] Deploy timing measurement"
+  echo "--------------------------------------------"
+
+  if [[ -z "$DEPLOY_APP" || -z "$DEPLOY_RG" ]]; then
+    echo "Warning: --deploy-app and --deploy-rg required for deploy timing. Skipping."
+  else
+    bash "$SCRIPT_DIR/deploy-timing.sh" \
+      --app-name "$DEPLOY_APP" \
+      --resource-group "$DEPLOY_RG" \
+      --output "$EVIDENCE_DIR/deploy-metrics.json" || true
+
+    echo ""
+    echo " [3/3] Deploy timing complete"
+  fi
+else
+  echo "--------------------------------------------"
+  echo " [3/3] Deploy timing — SKIPPED (use --deploy-timing to enable)"
+  echo "--------------------------------------------"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================"
+echo " Evidence Collection Complete"
+echo "============================================"
+echo ""
+echo "Evidence files in $EVIDENCE_DIR:"
+ls -la "$EVIDENCE_DIR/" 2>/dev/null || echo "  (none)"
+echo ""
+
+# Print key metrics if summaries exist
+for SUMMARY in "$RESULTS_DIR"/ramping-summary.json "$RESULTS_DIR"/throughput-summary.json; do
+  if [[ -f "$SUMMARY" ]]; then
+    TEST_NAME=$(basename "$SUMMARY" .json | sed 's/-summary//')
+    echo "--- $TEST_NAME ---"
+    # Extract key metrics using node (available in most dev environments)
+    if command -v node &> /dev/null; then
+      node -e "
+        const d = require('$SUMMARY');
+        const dur = d.metrics?.http_req_duration;
+        const reqs = d.metrics?.http_reqs;
+        const failed = d.metrics?.http_req_failed;
+        const checks = d.metrics?.checks;
+        console.log('  Avg response time: ' + (dur?.values?.avg?.toFixed(2) || 'N/A') + 'ms');
+        console.log('  P95 response time: ' + (dur?.values?.['p(95)']?.toFixed(2) || 'N/A') + 'ms');
+        console.log('  Request rate:      ' + (reqs?.values?.rate?.toFixed(2) || 'N/A') + ' req/s');
+        console.log('  Error rate:        ' + (failed?.values?.rate?.toFixed(4) || 'N/A'));
+        console.log('  Check pass rate:   ' + (checks?.values?.rate?.toFixed(4) || 'N/A'));
+      " 2>/dev/null || echo "  (could not parse summary)"
+    fi
+    echo ""
+  fi
+done
+
+echo "Done. Evidence is ready for the final report."


### PR DESCRIPTION
## Summary

Adds k6-based performance testing, deploy timing measurement, and evidence collection infrastructure for Issue #15.

## Changes

### Performance Testing (performance-test/)
- **load-test.js** — k6 script with two scenarios:
  - **Ramping VUs**: 0→20→50→100 VUs over ~6 min (proves concurrency and response time)
  - **Constant throughput**: 20 req/s arrival rate for 2 min (proves throughput SLO)
  - Pre-registers 60 test users in setup() to avoid auth rate limiter during tests
- **deploy-timing.sh** — Polls Azure Container Apps until unningStatus=Running, outputs deploy-metrics.json
- **un-tests.sh** — Orchestrator: runs k6 tests, copies evidence to docs/evidence/performance/

### CD Workflow (.github/workflows/cd.yml)
- Records deploy start/end timestamps in both staging and production jobs
- Polls unningStatus after deploy to confirm Container App is live
- Uploads deploy-metrics.json as a GitHub Actions artifact (30-day retention)

### Configurable Rate Limits
- RATE_LIMIT_AUTH_MAX, RATE_LIMIT_BOOKS_MAX, RATE_LIMIT_CART_MAX, RATE_LIMIT_PROFILE_MAX env vars (defaults unchanged)

### Evidence Index
- docs/evidence/performance/README.md — maps each metric to its target and evidence file

## Targets

| Metric | Target | Evidence |
|--------|--------|----------|
| Avg response time | ≤ 2s | amping-summary.json |
| Concurrent users | ≥ 50 | Ramping VUs scenario |
| Throughput | ≥ 20 req/s | 	hroughput-summary.json |
| Deploy time | ≤ 5 min | deploy-metrics.json artifact |

## Post-Merge Steps

After merging, set env vars on staging ACA to enable load testing:
\\\ash
az containerapp update --name bookrunner-backend-staging --resource-group blacksky-1181b208 --set-env-vars RATE_LIMIT_AUTH_MAX=5000 RATE_LIMIT_BOOKS_MAX=5000 RATE_LIMIT_CART_MAX=5000 RATE_LIMIT_PROFILE_MAX=5000
\\\

Closes #15